### PR TITLE
Add ability to send and receive the payload as an object

### DIFF
--- a/XKit.Lib.Common/Fabric/ServiceCallResult.cs
+++ b/XKit.Lib.Common/Fabric/ServiceCallResult.cs
@@ -8,6 +8,8 @@ namespace XKit.Lib.Common.Fabric {
 
     public class ServiceCallResult {
 
+        private string payload; 
+
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public ServiceCallStatusEnum ServiceCallStatus { get; set; } = ServiceCallStatusEnum.NotAttempted;
         
@@ -41,7 +43,14 @@ namespace XKit.Lib.Common.Fabric {
         [JsonIgnore]
         public bool Completed => this.ServiceCallStatus == ServiceCallStatusEnum.Completed;
 
-        public string Payload { get; set; }
+        public string Payload { 
+            get => payload; 
+            set {
+                if (value != null) {
+                    payload = value;
+                }
+            } 
+        }
 
         public T GetBody<T>() where T : class {
             return Json.FromJson<T>(this.Payload);
@@ -56,11 +65,11 @@ namespace XKit.Lib.Common.Fabric {
         }
 
         public void SetBody(object body) {
-            this.Payload = Json.ToJson(body);
+            payload = Json.ToJson(body);
         }
 
         public void SetBody<T>(T body) {
-            this.Payload = Json.ToJson<T>(body);
+            payload = Json.ToJson<T>(body);
         }
 
         public ServiceCallResult<T> ConvertTo<T>() where T : class

--- a/XKit.Lib.Host.Protocols.Http/Helpers/HttpServiceCallRequest.cs
+++ b/XKit.Lib.Host.Protocols.Http/Helpers/HttpServiceCallRequest.cs
@@ -1,0 +1,21 @@
+using XKit.Lib.Common.Fabric;
+using XKit.Lib.Common.Utility.Extensions;
+
+namespace XKit.Lib.Host.Protocols.Http.Helpers {
+
+    // NOTE: HttpServiceCallRequest provides just a tiny bit of extra functionality
+    //       to the plain ServiceCallRequest by adding the ability to get the payload
+    //       from an object.  This is useful when making a call from code which is 
+    //       external to XerviceKit by allowing the caller to specify an object instead of 
+    //       a json string for Payload.
+    public class HttpServiceCallRequest : ServiceCallRequest {
+        public bool UsesPayloadObj { get; private set; }
+
+        public dynamic PayloadObj {
+            set {
+                Payload = Json.ToJson(value);
+                UsesPayloadObj = true;
+            }
+        }
+    }
+}

--- a/XKit.Lib.Host.Protocols.Http/Helpers/HttpServiceCallResultUsingPayloadObj.cs
+++ b/XKit.Lib.Host.Protocols.Http/Helpers/HttpServiceCallResultUsingPayloadObj.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Text.Json.Serialization;
+using XKit.Lib.Common.Fabric;
+using XKit.Lib.Common.Log;
+using XKit.Lib.Common.Registration;
+using XKit.Lib.Common.Utility.Extensions;
+
+namespace XKit.Lib.Host.Protocols.Http.Helpers {
+
+    // NOTE: HttpServiceCallResultUsingPayloadObj changes the result slightly to use an object for PayloadObj
+    //       instead of a json string for Payload.  When the caller uses PayloadObj, it is understood
+    //       that the response should also use PayloadObj
+    public class HttpServiceCallResultUsingPayloadObj  {
+        private string payload; 
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public ServiceCallStatusEnum ServiceCallStatus { get; set; } = ServiceCallStatusEnum.NotAttempted;
+        
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public LogResultStatusEnum? OperationStatus { get; set; }
+        
+        public ServiceInstanceStatus ServiceStatus { get; set; }
+        public string Message { get; set; }
+        public string ResponderInstanceId { get; set; }
+        public string ResponderFabricId { get; set; }
+        public Guid OperationId { get; set; }
+        public string OperationName { get; set; }
+        public Descriptor Service { get; set; }
+        public string CorrelationId { get; set; }
+        public string RequestorInstanceId { get; set; }
+        public string RequestorFabricId { get; set; }
+        public object Code { get; set; }
+        public DateTime Timestamp { get; set; }
+
+        public static HttpServiceCallResultUsingPayloadObj CreateFrom(ServiceCallResult from) {
+            return new HttpServiceCallResultUsingPayloadObj {
+                Code = from.Code,
+                CorrelationId = from.CorrelationId,
+                Message = from.Message,
+                OperationId = from.OperationId,
+                OperationName = from.OperationName,
+                OperationStatus = from.OperationStatus,
+                Payload = from.Payload,
+                RequestorFabricId = from.RequestorFabricId,
+                RequestorInstanceId = from.RequestorInstanceId,
+                ResponderFabricId = from.ResponderFabricId,
+                ResponderInstanceId = from.ResponderInstanceId,
+                Service = from.Service,
+                ServiceCallStatus = from.ServiceCallStatus,
+                ServiceStatus = from.ServiceStatus,
+                Timestamp = from.Timestamp
+            };
+        }
+
+        public string Payload {
+            set => payload = value;
+        }
+
+        public dynamic PayloadObj {
+            get {
+                if (payload != null) {
+                    return Json.FromJson(payload);
+                }
+                return null;
+            }
+        }
+    }
+}

--- a/XKit.Lib.Host.Protocols.Http/Helpers/ServiceControllerBase.cs
+++ b/XKit.Lib.Host.Protocols.Http/Helpers/ServiceControllerBase.cs
@@ -47,7 +47,7 @@ namespace XKit.Lib.Host.Protocols.Http.Helpers {
 
             using var reader = new StreamReader(Request.Body);
             string content = await reader.ReadToEndAsync();
-            ServiceCallRequest request = Json.FromJson<ServiceCallRequest>(content);                        
+            HttpServiceCallRequest request = Json.FromJson<HttpServiceCallRequest>(content);                        
 
             ServiceCallResult result = null;
             Exception operationException = null;
@@ -57,7 +57,11 @@ namespace XKit.Lib.Host.Protocols.Http.Helpers {
                 operationException = ex; 
             }
             
-            return Ok(result);
+            if (request.UsesPayloadObj) {
+                return Ok(HttpServiceCallResultUsingPayloadObj.CreateFrom(result));
+            } else {
+                return Ok(result);
+            }
         }
     }
 }


### PR DESCRIPTION
When doing service calls from code external to XerviceKit (such as `curl`), it is quite annoying to have to convert the payload to a json string.  This change allows the passing a json object as `payloadObj` instead.  When the request uses `payloadObj`, then the response will also use `payloadObj` instead of `payload`. 